### PR TITLE
Clean up MetaMetaStrategy based on linter advice

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ gem 'httparty'
 group :development, :test do
   gem 'rake'
   gem 'foreman'
+  gem 'pry-byebug'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,6 +4,8 @@ GEM
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
     backports (3.8.0)
+    byebug (9.0.5)
+    coderay (1.1.1)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     diff-lcs (1.3)
@@ -13,10 +15,18 @@ GEM
     hashdiff (0.3.6)
     httparty (0.15.5)
       multi_xml (>= 0.5.2)
+    method_source (0.8.2)
     mock_redis (0.17.3)
     multi_json (1.12.2)
     multi_xml (0.6.0)
     mustermann (1.0.1)
+    pry (0.10.4)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
+    pry-byebug (3.4.0)
+      byebug (~> 9.0)
+      pry (~> 0.10)
     public_suffix (3.0.0)
     puma (3.10.0)
     rack (2.0.3)
@@ -52,6 +62,7 @@ GEM
       rack-protection (= 2.0.0)
       sinatra (= 2.0.0)
       tilt (>= 1.3, < 3)
+    slop (3.6.0)
     thor (0.19.4)
     tilt (2.0.8)
     vcr (3.0.3)
@@ -68,6 +79,7 @@ DEPENDENCIES
   foreman
   httparty
   mock_redis
+  pry-byebug
   puma
   rack-test
   rake

--- a/bots/most_frequent.rb
+++ b/bots/most_frequent.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+# MostFrequentBot
+class MostFrequentBot
+  COUNTERS = { 'r' => 'p', 'p' => 's', 's' => 'r' }.freeze
+
+  def move(opponent_moves)
+    histogram = opponent_moves.reduce(Hash.new(0)) do |hist, move|
+      # increment the moves count by one
+      hist.tap { |h| h[move] += 1 }
+    end
+
+    # return counter move for the most frequent
+    # opponent move
+    COUNTERS[histogram.to_a.max_by { |v| v[1] }[0]]
+  end
+end

--- a/meta_meta_strategy.rb
+++ b/meta_meta_strategy.rb
@@ -1,13 +1,14 @@
 require_relative 'bots/always_rock'
 require_relative 'bots/random'
 
-class MetaMetaStrategy
-	def initialize(previous_scores=nil)
-		@bots = {
-			"random" => RandomBot.new,
-			"always_rock" => AlwaysRockBot.new
-		}
+DEFAULT_BOTS = {
+  'random' => RandomBot.new,
+  'always_rock' => AlwaysRockBot.new
+}
 
+class MetaMetaStrategy
+	def initialize(previous_scores=nil, bots=DEFAULT_BOTS)
+		@bots = bots
 		@scores = previous_scores || scores_template(@bots)
 	end
 
@@ -44,15 +45,18 @@ class MetaMetaStrategy
 
 	def choose_best_bot
 		# bot with highest score (bluff or no bluff)
-		best_bot = @scores.max_by{ |s| s.max }[0]
+    best_arr[0]
 	end
 
 	def choose_best_move
-		best_arr = @scores.max_by{ |s| s[1..-1].max }
 		[best_arr[0], best_arr.index(best_arr[1..-1].max)]
 	end
 
 	private
+
+  def best_arr
+    @scores.max_by{ |s| s[1..-1].max }
+  end
 
 	def scores_template(bots)
 		@bots.map do |bot_name, bot|

--- a/meta_meta_strategy.rb
+++ b/meta_meta_strategy.rb
@@ -26,15 +26,13 @@ class MetaMetaStrategy
   attr_accessor :scores
 
   def move(opponent_moves)
-    if opponent_moves.length.positive?
-      run_bots(opponent_moves)
-      selected_bot, move_index = choose_best_move
-      potential_move = @bots[selected_bot].move(opponent_moves)
+    return %w[r p s].sample unless opponent_moves.length.positive?
 
-      calculate_move(potential_move, move_index)
-    else
-      %w[r p s].sample
-    end
+    run_bots(opponent_moves)
+    selected_bot, move_index = choose_best_move
+    potential_move = @bots[selected_bot].move(opponent_moves)
+
+    calculate_move(potential_move, move_index)
   end
 
   def run_bots(opponent_moves)
@@ -69,7 +67,7 @@ class MetaMetaStrategy
         score[idx + 1] += calculate_result(latest_move, move)
       end
 
-      [score[0], score[1], score[2], score[3]]
+      score
     end
   end
 

--- a/meta_meta_strategy.rb
+++ b/meta_meta_strategy.rb
@@ -14,12 +14,8 @@ DEFAULT_BOTS = {
 # which one is likely in play (along with the possibility of a bluff or double
 # bluff of that strategy) and suggests a move to combat said strategy.
 class MetaMetaStrategy
-  def initialize(previous_scores = nil)
-    @bots = {
-      'random' => RandomBot.new,
-      'always_rock' => AlwaysRockBot.new,
-      'most_frequent' => MostFrequentBot.new
-    }
+  def initialize(previous_scores = nil, bots = DEFAULT_BOTS)
+    @bots = bots
 
     @scores = previous_scores || scores_template(@bots)
   end

--- a/meta_meta_strategy.rb
+++ b/meta_meta_strategy.rb
@@ -1,110 +1,112 @@
+# frozen_string_literal: true
+
 require_relative 'bots/always_rock'
+require_relative 'bots/most_frequent'
 require_relative 'bots/random'
 
 DEFAULT_BOTS = {
   'random' => RandomBot.new,
-  'always_rock' => AlwaysRockBot.new
-}
+  'always_rock' => AlwaysRockBot.new,
+  'most_frequent' => MostFrequentBot.new
+}.freeze
 
+# MetaMetaStrategy is a RPS bot which decides based on a set of strategies,
+# which one is likely in play (along with the possibility of a bluff or double
+# bluff of that strategy) and suggests a move to combat said strategy.
 class MetaMetaStrategy
-	def initialize(previous_scores=nil, bots=DEFAULT_BOTS)
-		@bots = bots
-		@scores = previous_scores || scores_template(@bots)
-	end
+  def initialize(previous_scores = nil)
+    @bots = {
+      'random' => RandomBot.new,
+      'always_rock' => AlwaysRockBot.new
+    }
 
-	attr_accessor :scores
-
-	def move(opponent_moves)
-		if opponent_moves.length > 0
-			run_bots(opponent_moves)
-			selected_bot, move_index = choose_best_move
-			potential_move = @bots[selected_bot].move(opponent_moves)
-
-			calculate_move(potential_move, move_index)
-		else
-			['r','p','s'].sample
-		end
-	end
-
-	def run_bots(opponent_moves)
-		latest_move = opponent_moves.pop(1)[0]
-
-		if opponent_moves.length > 0
-			@scores.map do |score|
-
-				bot = @bots[score[0]]
-				response = bot.move(opponent_moves)
-				score[1] += calculate_result(latest_move, response)
-				score[2] += calculate_result(latest_move, bluff_move(response))
-				score[3] += calculate_result(latest_move, double_bluff_move(response))
-
-				[score[0], score[1], score[2], score[3]]
-			end
-		end
-	end
-
-	def choose_best_bot
-		# bot with highest score (bluff or no bluff)
-    best_arr[0]
-	end
-
-	def choose_best_move
-		[best_arr[0], best_arr.index(best_arr[1..-1].max)]
-	end
-
-	private
-
-  def best_arr
-    @scores.max_by{ |s| s[1..-1].max }
+    @scores = previous_scores || scores_template(@bots)
   end
 
-	def scores_template(bots)
-		@bots.map do |bot_name, bot|
-			# bot name, straight move, bluff move, double bluff move
-			[bot_name, 0, 0, 0]
-		end
-	end
+  attr_accessor :scores
 
-	def calculate_result(opp_move, move)
-		if opp_move == move
-			0
-		else
-			case opp_move + move
-			when "rp", "ps", "sr"
-  			1
-			when "rs", "pr", "sp"
-  			-1
-			end
-  	end
-	end
+  def move(opponent_moves)
+    if opponent_moves.length.positive?
+      run_bots(opponent_moves)
+      selected_bot, move_index = choose_best_move
+      potential_move = @bots[selected_bot].move(opponent_moves)
 
-	def bluff_move(move)
-		{ "r" => "s",
-			"p" => "r",
-			"s" => "p"
-			}[move]
-	end
+      calculate_move(potential_move, move_index)
+    else
+      %w[r p s].sample
+    end
+  end
 
-	def double_bluff_move(move)
-		{ "r" => "p",
-			"p" => "s",
-			"s" => "r"
-			}[move]
-	end
+  def run_bots(opponent_moves)
+    latest_move = opponent_moves.pop(1)[0]
 
-	def calculate_move(move, bluff_index)
-		puts "BLUFF INDEX"
-		puts bluff_index
-		case bluff_index
-		when 1
-			puts "JUST MOVE"
-			move
-		when 2
-			puts "BLUFF"
-			bluff_move(move)
-		when 3
-			puts "DOUBLE BLUFF"
-			double_bluff_move(move)
-		end
-	end
+    return unless opponent_moves.length.positive?
+
+    run_bots_for_move(opponent_moves, latest_move)
+  end
+
+  def choose_best_bot
+    # bot with highest score (bluff or no bluff)
+    best_arr[0]
+  end
+
+  def choose_best_move
+    [best_arr[0], best_arr.index(best_arr[1..-1].max)]
+  end
+
+  private
+
+  def best_arr
+    @scores.max_by { |s| s[1..-1].max }
+  end
+
+  def run_bots_for_move(opponent_moves, latest_move)
+    @scores.map do |score|
+      bot = @bots[score[0]]
+      response = bot.move(opponent_moves)
+      all_moves = [response, bluff_move(response), double_bluff_move(response)]
+      all_moves.each_with_index do |move, idx|
+        score[idx + 1] += calculate_result(latest_move, move)
+      end
+
+      [score[0], score[1], score[2], score[3]]
+    end
+  end
+
+  def scores_template(bots)
+    bots.map do |bot_name, _bot|
+      # bot name, straight move, bluff move, double bluff move
+      [bot_name, 0, 0, 0]
+    end
+  end
+
+  def calculate_result(opp_move, move)
+    return 0 if opp_move == move
+    case opp_move + move
+    when 'rp', 'ps', 'sr'
+      1
+    when 'rs', 'pr', 'sp'
+      -1
+    end
+  end
+
+  def bluff_move(move)
+    {
+      'r' => 's',
+      'p' => 'r',
+      's' => 'p'
+    }[move]
+  end
+
+  def double_bluff_move(move)
+    {
+      'r' => 'p',
+      'p' => 's',
+      's' => 'r'
+    }[move]
+  end
+
+  def calculate_move(move, bluff_index)
+    [move, bluff_move(move), double_bluff_move(move)][bluff_index - 1]
+  end
 end

--- a/meta_meta_strategy.rb
+++ b/meta_meta_strategy.rb
@@ -17,7 +17,8 @@ class MetaMetaStrategy
   def initialize(previous_scores = nil)
     @bots = {
       'random' => RandomBot.new,
-      'always_rock' => AlwaysRockBot.new
+      'always_rock' => AlwaysRockBot.new,
+      'most_frequent' => MostFrequentBot.new
     }
 
     @scores = previous_scores || scores_template(@bots)

--- a/spec/meta_meta_strategy_spec.rb
+++ b/spec/meta_meta_strategy_spec.rb
@@ -1,0 +1,77 @@
+require 'spec_helper'
+
+# OneMoveBot
+class OneMoveBot
+  def initialize(move)
+    @move = move
+  end
+
+  def move(_)
+    @move
+  end
+end
+
+# CycleBot
+class CycleBot
+  def initialize
+    @index = 0
+  end
+
+  def move(_)
+    @index += 1
+    %w[r p s][@index % 3]
+  end
+end
+
+describe MetaMetaStrategy do
+  subject { MetaMetaStrategy }
+
+  context '#scores' do
+    let(:strategy) { subject.new(nil, 'paper_bot' => OneMoveBot.new('p')) }
+    let(:expected_scores) { [['paper_bot', 0, 0, 0]] }
+
+    it 'returns the blank scores as expected' do
+      expect(strategy.scores).to eq expected_scores
+    end
+  end
+
+  context 'some previous scores' do
+    let(:previous_scores) { [['a', 0, 5, 0], ['b', 1, 2, 3], ['c', 0, 2, 7]] }
+    let(:strategy) { subject.new(previous_scores) }
+
+    describe '#choose_best_bot' do
+      it 'returns c' do
+        expect(strategy.choose_best_bot).to eq 'c'
+      end
+    end
+
+    describe '#choose_best_move' do
+      it "returns ['c', 3]" do
+        expect(strategy.choose_best_move).to eq ['c', 3]
+      end
+    end
+  end
+
+  describe '#move' do
+    let(:strategies) do
+      {
+        'cycle_bot' => CycleBot.new,
+        'scissor_bot' => OneMoveBot.new('s')
+      }
+    end
+
+    let(:strategy) { subject.new(nil, strategies) }
+    let(:scissor) { 's' }
+    let(:moves) { [scissor, scissor, scissor, scissor] }
+
+    it 'returns an appropriate counter move' do
+      result = ''
+      0.upto(moves.size - 1).each do |i|
+        result = strategy.move(moves[0..i])
+      end
+
+      expect(result).to eq 'r'
+      expect(strategy.choose_best_bot).to eq 'scissor_bot'
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,7 @@ require 'rack/test'
 require 'rspec'
 require 'mock_redis'
 require 'dotenv'
+require 'pry'
 
 Dotenv.load('.env.test')
 


### PR DESCRIPTION
This addresses some of the linter concerns for the MetaMetaStrategy
class. It breaks some of the more complex methods down, to hush the
branch condition linter. It also does some re-indenting and removes some
print statements.